### PR TITLE
Fix Whipple state update

### DIFF
--- a/src/bicycle/whipple.cc
+++ b/src/bicycle/whipple.cc
@@ -59,7 +59,7 @@ BicycleWhipple::BicycleWhipple(real_t v, real_t dt
 
 BicycleWhipple::state_t BicycleWhipple::update_state(const BicycleWhipple::state_t& x, const BicycleWhipple::input_t& u, const BicycleWhipple::measurement_t& z) const {
     (void)z;
-    return m_A*x + m_B*u;
+    return m_Ad*x + m_Bd*u;
 }
 
 BicycleWhipple::output_t BicycleWhipple::calculate_output(const BicycleWhipple::state_t& x, const BicycleWhipple::input_t& u) const {


### PR DESCRIPTION
The update_state() member function is a function that uses the discrete
time system and advances the state by the timestep stored in the system.
The new state must be calculated using the discrete time versions of the
state space matrices.