### PR TITLE
Normalize output in Kalman measurement update

### DIFF
--- a/src/bicycle/bicycle.cc
+++ b/src/bicycle/bicycle.cc
@@ -2,11 +2,10 @@
 #include <cmath>
 #include <fstream>
 #include <stdexcept>
-//#include <tuple>
 #include <type_traits>
-//#include <boost/math/tools/roots.hpp>
 #include "bicycle/bicycle.h"
 #include "parameters.h"
+#include "angle.h"
 
 namespace {
     template <typename E>
@@ -380,7 +379,8 @@ Bicycle::output_t Bicycle::normalize_output(const output_t& y) const {
         "Invalid underlying value for output index element");
 
     output_t normalized_y = y;
-    mod_two_pi_element(normalized_y, output_index_t::yaw_angle);
+    set_element(normalized_y, output_index_t::yaw_angle,
+            angle::wrap(get_element(y, output_index_t::yaw_angle)));
     mod_two_pi_element(normalized_y, output_index_t::steer_angle);
     return normalized_y;
 }

--- a/src/kalman.hh
+++ b/src/kalman.hh
@@ -118,7 +118,8 @@ void Kalman<T>::measurement_update_kalman_gain(const measurement_noise_covarianc
 
 template <typename T>
 void Kalman<T>::measurement_update_state(const measurement_t& z) {
-    m_x = m_system.normalize_state(m_x + m_K*(z - m_system.Cd()*m_x));
+    m_x = m_system.normalize_state(m_x + m_K*(
+                m_system.normalize_output(z - m_system.Cd()*m_x)));
 }
 
 template <typename T>


### PR DESCRIPTION
Normalize the output term (z - C*x) in the Kalman member function
measurement_update_state() prevent erroneous changes in the updated
state in the event that the output term is not within the output range.

Fixes https://github.com/oliverlee/phobos/issues/69