### PR TITLE
Fix bicycle output normalization

### DIFF
--- a/src/bicycle/bicycle.cc
+++ b/src/bicycle/bicycle.cc
@@ -5,7 +5,6 @@
 #include <type_traits>
 #include "bicycle/bicycle.h"
 #include "parameters.h"
-#include "angle.h"
 
 namespace {
     template <typename E>
@@ -379,8 +378,15 @@ Bicycle::output_t Bicycle::normalize_output(const output_t& y) const {
         "Invalid underlying value for output index element");
 
     output_t normalized_y = y;
-    set_element(normalized_y, output_index_t::yaw_angle,
-            angle::wrap(get_element(y, output_index_t::yaw_angle)));
+
+    auto yaw = std::fmod(get_element(y, output_index_t::yaw_angle), constants::two_pi);
+    if (yaw >= constants::pi) {
+        yaw -= constants::two_pi;
+    } else if (yaw < -constants::pi) {
+        yaw += constants::two_pi;
+    }
+
+    set_element(normalized_y, output_index_t::yaw_angle, yaw);
     mod_two_pi_element(normalized_y, output_index_t::steer_angle);
     return normalized_y;
 }


### PR DESCRIPTION
File angle.h does not exist in the repository and yaw angle must be
in the range [-pi, pi).