### PR TITLE
Make LQR perform_value_iteration() public

### DIFF
--- a/inc/lqr.h
+++ b/inc/lqr.h
@@ -27,6 +27,8 @@ class Lqr {
 
         input_t control_calculate(const state_t& x);
         input_t control_calculate(const state_t& x, const state_t& r);
+        void perform_value_iteration(); // uses m_horizon
+        void perform_value_iteration(uint32_t horizon_iterations);
 
         void set_horizon(uint32_t horizon_iterations);
         void set_reference(const state_t& r);
@@ -75,7 +77,6 @@ class Lqr {
         augmented_lqr_gain_t m_Kg;          // computed feedback gain (standard + integral/tracking)
         augmented_state_cost_t m_Pg;        // augmented cost-to-go matrix
 
-        void perform_value_iteration();
         void update_lqr_gain();
         void update_horizon_cost();
         void set_control_mask();

--- a/src/lqr.hh
+++ b/src/lqr.hh
@@ -54,6 +54,11 @@ typename Lqr<T>::input_t Lqr<T>::control_calculate(const state_t& x, const state
 
 template<typename T>
 void Lqr<T>::perform_value_iteration() {
+    perform_value_iteration(m_horizon);
+}
+
+template<typename T>
+void Lqr<T>::perform_value_iteration() {
     if (!m_system.Ad().isApprox(m_Ag.template topLeftCorner<T::n, T::n>()) ||
             !m_system.Bd().isApprox(m_Bd)) {
         // check if system has changed


### PR DESCRIPTION
Change Lqr<T>::perform_value_iteration() from a private member function
to a public member function to allow a user to update the LQR feedback
gain without calculating the feedback input. Define an alternate member
function prototype that allows the number of horizon iterations to
specified when performing value iteration instead of using the class
horizon member variable.